### PR TITLE
Add `fromString` method

### DIFF
--- a/src/Data/Number.js
+++ b/src/Data/Number.js
@@ -1,0 +1,10 @@
+exports.fromStringImpl = function (just) {
+  return function (nothing) {
+    return function (string) {
+      var result = parseFloat(string);
+
+      return isNaN(result) ? nothing
+                           : just(result);
+    };
+  };
+};

--- a/src/Data/Number.purs
+++ b/src/Data/Number.purs
@@ -5,6 +5,7 @@ module Data.Number
   , eqApproximate
   , (~=)
   , (≅)
+  , fromString
   , neqApproximate
   , (≇)
   , Precision
@@ -13,7 +14,36 @@ module Data.Number
 
 import Prelude
 
+import Data.Maybe (Maybe(..))
 import Math (abs)
+
+
+foreign import fromStringImpl
+  :: (forall a. a -> Maybe a)
+  -> (forall a. Maybe a)
+  -> String
+  -> Maybe Number
+
+
+-- | Attempt to parse a Number from a String using JavaScript's parseFloat.
+-- |
+-- | Example:
+-- | ```purs
+-- | > fromString "123"
+-- | (Just 123.0)
+-- |
+-- | > fromString "12.34"
+-- | (Just 12.34)
+-- |
+-- | > fromString "1e4"
+-- | (Just 10000.0)
+-- |
+-- | > fromString "1.2e4"
+-- | (Just 12000.0)
+-- | ```
+fromString :: String -> Maybe Number
+fromString = fromStringImpl Just Nothing
+
 
 -- | A type alias for (small) numbers, typically in the range *[0:1]*.
 type Fraction = Number

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -2,7 +2,8 @@ module Test.Main where
 
 import Prelude
 
-import Data.Number (eqRelative, eqAbsolute, (≅), (≇))
+import Data.Maybe (fromMaybe)
+import Data.Number (eqRelative, eqAbsolute, fromString, (≅), (≇))
 
 import Control.Monad.Aff.AVar (AVAR)
 import Control.Monad.Eff (Eff)
@@ -117,6 +118,25 @@ main = runTest do
 
       assert "0.1 + 0.200001 should not be approximately equal to 0.3" $
         0.1 + 0.200001 ≇ 0.3
+
+
+  suite "fromString" do
+    test "valid number string" do
+      assert "integer strings are coerced" $
+        fromMaybe false $ map (_ == 123.0) $ fromString "123"
+
+      assert "decimals are coerced" $
+        fromMaybe false $ map (_ == 12.34) $ fromString "12.34"
+
+      assert "exponents are coerced" $
+        fromMaybe false $ map (_ == 1e4) $ fromString "1e4"
+
+      assert "decimals exponents are coerced" $
+        fromMaybe false $ map (_ == 1.2e4) $ fromString "1.2e4"
+
+    test "invalid number string" do
+      assert "invalid strings are not coerced" $
+        fromMaybe true $ false <$ fromString "bad string"
 
 
   suite "eqAbsolute" do


### PR DESCRIPTION
Hello!

This is the `Number` equivalent of `Data.Int.fromString`. Hope this is ok! I've added tests to the suite, too.

PS: I looked at the process of re-uploading packages, and, while I think I probably _can_ do it, it would result in me being registered as the package uploader. Not quite sure what the repercussions are, so I'm going to run away and leave it to you. Probably being silly, but best to be safe.